### PR TITLE
Re: Google Addons

### DIFF
--- a/cyanogenmod.js
+++ b/cyanogenmod.js
@@ -34,7 +34,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -55,7 +55,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -76,7 +76,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -97,7 +97,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -137,7 +137,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -175,7 +175,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -483,7 +483,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -499,7 +499,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -517,7 +517,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -533,7 +533,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -549,7 +549,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
         }
         ]
     },
@@ -592,7 +592,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-mdpi-tiny-20100816-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-mdpi-tiny-20100930-signed.zip"
         }
         ]
     },
@@ -611,7 +611,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-mdpi-tiny-20100816-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-mdpi-tiny-20100930-signed.zip"
         }
         ]
     },
@@ -628,7 +628,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-mdpi-tiny-20100816-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-mdpi-tiny-20100930-signed.zip"
         }
         ]
     },
@@ -668,7 +668,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-mdpi-tiny-20100816-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-mdpi-tiny-20100930-signed.zip"
         }
         ]
     },
@@ -684,7 +684,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-mdpi-tiny-20100816-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-mdpi-tiny-20100930-signed.zip"
         }
         ]
     },
@@ -828,7 +828,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-mdpi-20100816-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-mdpi-20100930-signed.zip"
         }
         ]
     },
@@ -844,7 +844,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-mdpi-20100816-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-mdpi-20100930-signed.zip"
         }
         ]
     },
@@ -862,7 +862,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-mdpi-20100816-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-mdpi-20100930-signed.zip"
         }
         ]
     },
@@ -880,7 +880,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-mdpi-20100816-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-mdpi-20100930-signed.zip"
         }
         ]
     },
@@ -897,7 +897,7 @@
         [
         {
             name: "Google Apps",
-            url: "http://mirror.kanged.net/gapps/gapps-mdpi-20100816-signed.zip"
+            url: "http://mirror.teamdouche.net/get/various/gapps-mdpi-20100930-signed.zip"
         }
         ]
     },
@@ -907,19 +907,19 @@
         name: "Google Apps (Froyo)",
         summary: "Google Add-On",
         device: "passion",
-        url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+        url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
     },
     {
         name: "Google Apps (Froyo)",
         summary: "Google Add-On",
         device: "sholes",
-        url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+        url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
     },
     {
         name: "Google Apps (Froyo)",
         summary: "Google Add-On",
         device: "inc",
-        url: "http://mirror.kanged.net/gapps/gapps-hdpi-20100817-signed.zip"
+        url: "http://mirror.teamdouche.net/get/various/gapps-hdpi-20100930-signed.zip"
     },
 
     {


### PR DESCRIPTION
All former links were pointing to old mirror system and 8/17 or 9/17 Google Addon Packages. Neither of these exist on the newer mirror system (only 9/26 and later). 

This is my first time using Github, but I'm pretty sure I didnt break anything :)
