### PR TITLE
Added Captivate, Vibrant and i9000 reboot_recovery

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -705,18 +705,21 @@
     {
       "name": "Captivate (MTD)",
       "version": "3.0.2.5",
-      "readonly_recovery": true,
+      "reboot_recovery": "echo 1 > /cache/.startrecovery ; sync ; reboot ;",
+      "officially_supported": false,
       "init": "init.aries.rc",
       "key": "captivatemtd"
     },
     {
       "name": "Vibrant (MTD)",
+      "reboot_recovery": "echo 1 > /cache/.startrecovery ; sync ; reboot ;",
       "init": "init.aries.rc",
       "officially_supported": false,
       "key": "vibrantmtd"
     },
     {
       "name": "i9000 (MTD)",
+      "reboot_recovery": "echo 1 > /cache/.startrecovery ; sync ; reboot ;",
       "init": "init.aries.rc",
       "officially_supported": false,
       "key": "i9000mtd"


### PR DESCRIPTION
SGS phones need echo 1 > /cache/.startrecovery for the CM7 versions.
