### PR TITLE
galaxys2

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -923,8 +923,15 @@
     },
     {
       "name": "Samsung Galaxy S2",
-      "version": "4.0.0.2",
+      "version": "4.0.1.4",
       "init": "init.smdkc210.rc",
+      "readonly_recovery": true,
+      "key": "galaxys2"
+    },
+    {
+      "name": "Samsung Galaxy S2 (CM7)",
+      "version": "4.0.1.4",
+      "init": "init.smdkv310.rc",
       "readonly_recovery": true,
       "key": "galaxys2"
     },

--- a/manifest/galaxys2.js
+++ b/manifest/galaxys2.js
@@ -17,6 +17,14 @@
       "summary": "Add-on for AOSP ROMs, such as CM"
     },
     {
+      "developer": "Radio Images",
+      "icon": "http://koush.kanged.net/cm/test/extras.png",
+      "id": "teamhacksung",
+      "free": "true",
+      "manifest": "https://raw.github.com/teamhacksung/rommanager/gingerbread/galaxys2/radios/manifest.js",
+      "summary": "CWM-flashable Radio Images"
+    },
+    {
       "developer": "DesignGears Roms",
       "free": true,
       "icon": "http://romshare.deployfu.com/downloads/271/3ee39ba3530e8d858bbbfdbbb1ae2bea.png",

--- a/manifests.js
+++ b/manifests.js
@@ -46,7 +46,8 @@
         "buzz": "true",
         "z71": "true",
         "heroc": "true",
-        "zero": "true"
+        "zero": "true",
+        "galaxys2": "true"
       },
       "summary": "Mods and bacon for your phone"
     },
@@ -107,7 +108,8 @@
         "buzz": "true",
         "z71": "true",
         "heroc": "true",
-        "zero": "true"
+        "zero": "true",
+        "galaxys2": "true"
       },
       "summary": "CyanogenMod Nightly builds. Very experimental and probably broken.  Do not report bugs for these builds."
     },


### PR DESCRIPTION
hi koush.

enabled nightly support for galaxys2.

goo-inside.me is hosting cwm flashable radio images for galaxys2 now.
i've added it and will maintain our manifest on teamhacksung github account.
https://github.com/teamhacksung/rommanager/blob/gingerbread/galaxys2/radios/manifest.js

hope it's ok for you.
