### PR TITLE
Remove duplicate/invalid i9000 (MTD)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -309,19 +309,6 @@
       "key": "espresso"
     },
     {
-      "name": "Samsung GalaxyS i9000",
-      "version": "2.5.1.2",
-      "readonly_recovery": true,
-      "init": "lpm.rc",
-      "legacy_versions": [
-        "2.5.1.2",
-        "2.5.1.4",
-        "2.5.1.3",
-        "2.5.1.1"
-      ],
-      "key": "galaxys"
-    },
-    {
       "name": "Samsung GalaxyS Fascinate",
       "version": "3.0.0.8",
       "readonly_recovery": true,


### PR DESCRIPTION
Currently users see two i9000 (MTD) entries.
Only one of them actually works, whereas the other one when booted into recovery shows the error icon.
I believe we talked about this, not sure if you recall.

I have no way to test this change, but i am quite certain this is the invalid entry.
