### PR TITLE
LG Connect 4G and LG Lucid

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1873,6 +1873,26 @@
       "key": "wingray",
       "lunch": "cm_wingray-userdebug"
     }
+    {
+      "name": "LG Connect 4G MS840",
+      "version": "5.5.0.4",
+      "init": "init.cayman.rc",
+      "legacy_versions": [
+
+      ],
+      "key": "ms840",
+      "lunch": "full_ms840-eng"
+    },
+    {
+      "name": "LG Lucid VS840",
+      "version": "5.5.0.4",
+      "init": "init.cayman.rc",
+      "legacy_versions": [
+
+      ],
+      "key": "vs840",
+      "lunch": "full_vs840-eng"
+    },
   ],
   "use_in_app": false,
   "pontiflex_startup_register": 100,

--- a/manifest/ms840.js
+++ b/manifest/ms840.js
@@ -1,0 +1,53 @@
+{
+  "manifests": [
+    {
+      "developer": "Font Packs for Android 4.0",
+      "free": false,
+      "icon": "http://developer.clockworkmod.com/downloads/4783/594317ae2c2903718d5667c50293fab5.png",
+      "id": "ThugEsquire",
+      "manifest": "http://developer.clockworkmod.com/developer/ThugEsquire/manifest",
+      "summary": "Font packs for Android 4.0 (Ice Cream Sandwich) ONLY. Will not work on Android 2.x (Froyo/Gingerbread)."
+    },
+    {
+      "developer": "Cerberus",
+      "free": "true",
+      "id": "cerberusapp",
+      "icon": "http://www.cerberusapp.com/updates/icon.png",
+      "manifest": "http://www.cerberusapp.com/updates/manifest.js",
+      "summary": "Triple protection for your Android device"
+    },
+    {
+      "developer": "Superuser",
+      "free": "true",
+      "id": "chainsdd",
+      "icon": "http://chainsdd.github.com/Superuser/icon.png",
+      "manifest": "http://chainsdd.github.com/Superuser/manifest.js",
+      "summary": "Managing root like it's going out of style"
+    },
+    {
+      "developer": "ClockworkMod",
+      "featured": true,
+      "free": "true",
+      "id": "clockworkmod",
+      "icon": "http://bit.ly/xOLFbJ",
+      "manifest": "http://gh-pages.clockworkmod.com/ROMManagerManifest/clockworkmod.js",
+      "summary": "Awesome ROMs and apps from the creator of ROM Manager!"
+    },
+    {
+      "developer": "Google Apps",
+      "free": "true",
+      "id": "google",
+      "icon": "http://drmacinyasha.github.com/proprietary_vendor_google/icon.png",
+      "manifest": "http://drmacinyasha.github.com/proprietary_vendor_google/manifest.js",
+      "summary": "Add-on for AOSP ROMs, such as CM"
+    },
+    {
+      "developer": "vorobei1382@gmail.com",
+      "free": false,
+      "id": "vorobei1382@gmail.com",
+      "manifest": "http://developer.clockworkmod.com/developer/vorobei1382@gmail.com/manifest",
+      "summary": "vorobei1382@gmail.com"
+    }
+  ],
+  "minversion": "5006"
+}

--- a/manifest/vs840.js
+++ b/manifest/vs840.js
@@ -1,0 +1,53 @@
+{
+  "manifests": [
+    {
+      "developer": "Font Packs for Android 4.0",
+      "free": false,
+      "icon": "http://developer.clockworkmod.com/downloads/4783/594317ae2c2903718d5667c50293fab5.png",
+      "id": "ThugEsquire",
+      "manifest": "http://developer.clockworkmod.com/developer/ThugEsquire/manifest",
+      "summary": "Font packs for Android 4.0 (Ice Cream Sandwich) ONLY. Will not work on Android 2.x (Froyo/Gingerbread)."
+    },
+    {
+      "developer": "Cerberus",
+      "free": "true",
+      "id": "cerberusapp",
+      "icon": "http://www.cerberusapp.com/updates/icon.png",
+      "manifest": "http://www.cerberusapp.com/updates/manifest.js",
+      "summary": "Triple protection for your Android device"
+    },
+    {
+      "developer": "Superuser",
+      "free": "true",
+      "id": "chainsdd",
+      "icon": "http://chainsdd.github.com/Superuser/icon.png",
+      "manifest": "http://chainsdd.github.com/Superuser/manifest.js",
+      "summary": "Managing root like it's going out of style"
+    },
+    {
+      "developer": "ClockworkMod",
+      "featured": true,
+      "free": "true",
+      "id": "clockworkmod",
+      "icon": "http://bit.ly/xOLFbJ",
+      "manifest": "http://gh-pages.clockworkmod.com/ROMManagerManifest/clockworkmod.js",
+      "summary": "Awesome ROMs and apps from the creator of ROM Manager!"
+    },
+    {
+      "developer": "Google Apps",
+      "free": "true",
+      "id": "google",
+      "icon": "http://drmacinyasha.github.com/proprietary_vendor_google/icon.png",
+      "manifest": "http://drmacinyasha.github.com/proprietary_vendor_google/manifest.js",
+      "summary": "Add-on for AOSP ROMs, such as CM"
+    },
+    {
+      "developer": "vorobei1382@gmail.com",
+      "free": false,
+      "id": "vorobei1382@gmail.com",
+      "manifest": "http://developer.clockworkmod.com/developer/vorobei1382@gmail.com/manifest",
+      "summary": "vorobei1382@gmail.com"
+    }
+  ],
+  "minversion": "5006"
+}


### PR DESCRIPTION
Following Playfulgods advice i submitted an issue, but i figured this would be a better way to do it. the LG Cayman is the same device re-branded across 3 devices. the LG Connect 4G on MetroPCS, LG Lucid on verizon, and the LG Viper 4G on sprint. i have not yet had a chance to verify that the same prebuilt kernel will work on the Viper, but i can confirm it works fine on the lucid/connect.

This is the first time I've attempted to submit CWM for approval so if I've done something wrong please let me know :)

device profiles can be found here:

https://github.com/Shabbypenguin/android_device_lge_ms840

https://github.com/Shabbypenguin/android_device_lge_vs840
