### PR TITLE
Remove LG Optimus V support

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1153,15 +1153,6 @@
       "init": "init.vivow.rc"
     },
     {
-      "key": "thunderc",
-      "version": "3.2.0.1",
-      "name": "LGE Optimus V",
-      "legacy_versions": [
-
-      ],
-      "init": "init.cappuccino.rc"
-    },
-    {
       "touch_version": "5.8.1.5",
       "key": "p920",
       "version": "5.0.2.7",


### PR DESCRIPTION
The recovery rom manager flashes is useless on newer devices. No rom developers officially support rom manager. Everything in it is old, unsupported, and uploaded by people other than the devs.
Doing this will finally get rid of the annoying posts by noobs who "brick" their device by installing the recovery this app flashes (which has a older kernel that doesn't support the newer displays found in the current version of this phone). 
