### PR TITLE
Fix Acer A700 detection

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -2519,7 +2519,7 @@
       "legacy_versions": [
 
       ],
-      "init": "init.a700.rc",
+      "init": "init.picasso_mf.rc",
       "name": "Acer A700"
     },
     {


### PR DESCRIPTION
init.picasso_mf.rc not init.a700.rc
